### PR TITLE
Fix for ie11

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-runtime": "^6.26.0",
     "buffer-crc32": "^0.2.13",
     "cross-fetch": "^2.1.0",
+    "es6-promisify": "^6.0.1",
     "long": "^4.0.0",
     "md5": "^2.2.1",
     "quick-lru": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "es6-promisify": "^6.0.1",
     "long": "^4.0.0",
     "md5": "^2.2.1",
-    "quick-lru": "^2.0.0",
-    "util.promisify": "^1.0.0"
+    "quick-lru": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "buffer-crc32": "^0.2.13",
     "cross-fetch": "^2.1.0",
     "long": "^4.0.0",
-    "lru-cache": "^4.1.3",
     "md5": "^2.2.1",
+    "quick-lru": "^2.0.0",
     "util.promisify": "^1.0.0"
   },
   "devDependencies": {

--- a/src/craiIndex.js
+++ b/src/craiIndex.js
@@ -1,4 +1,4 @@
-const promisify = require('util.promisify')
+const {promisify} = require('es6-promisify')
 const zlib = require('zlib')
 
 const gunzip = promisify(zlib.gunzip)

--- a/src/cramFile/file.js
+++ b/src/cramFile/file.js
@@ -1,6 +1,6 @@
 const zlib = require('zlib')
 const crc32 = require('buffer-crc32')
-const LRU = require('lru-cache')
+const LRU = require('quick-lru')
 
 const { CramUnimplementedError, CramMalformedError } = require('../errors')
 const rans = require('../rans')
@@ -41,9 +41,8 @@ class CramFile {
     // slice offset. caches all of the features in a slice, or none.
     // the cache is actually used by the slice object, it's just
     // kept here at the level of the file
-    this.featureCache = LRU({
-      max: this.options.cacheSize,
-      length: featureArray => featureArray.length,
+    this.featureCache = new LRU({
+      maxSize: this.options.cacheSize
     })
   }
 

--- a/src/io/bufferCache.js
+++ b/src/io/bufferCache.js
@@ -1,11 +1,11 @@
-const LRU = require('lru-cache')
+const LRU = require('quick-lru')
 
 class BufferCache {
   constructor({ fetch, size = 10000000, chunkSize = 32768 }) {
     if (!fetch) throw new Error('fetch function required')
     this.fetch = fetch
     this.chunkSize = chunkSize
-    this.lruCache = LRU({ max: Math.floor(size / chunkSize) })
+    this.lruCache = new LRU({ maxSize: Math.floor(size / chunkSize) })
   }
   async get(outputBuffer, offset, length, position) {
     if (outputBuffer.length < offset + length)

--- a/src/io/localFile.js
+++ b/src/io/localFile.js
@@ -1,4 +1,4 @@
-const promisify = require('util.promisify')
+const {promisify} = require('es6-promisify')
 
 // don't load fs native module if running in webpacked code
 const fs = typeof __webpack_require__ !== 'function' ? require('fs') : null // eslint-disable-line camelcase

--- a/yarn.lock
+++ b/yarn.lock
@@ -2908,6 +2908,11 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
+es6-promisify@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.0.1.tgz#6edaa45f3bd570ffe08febce66f7116be4b1cdb6"
+  integrity sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==
+
 es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5192,7 +5192,7 @@ lru-cache@2.2.x:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
 
-lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
+lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@^4.1.2:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:
@@ -6599,6 +6599,11 @@ querystring-es3@^0.2.0:
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+
+quick-lru@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-2.0.0.tgz#32b017b28d1784631c8ab0a1ed2978e094dbe181"
+  integrity sha512-DqOtZziv7lDjEyuqyVQacRciAwMCEjTNrLYCHYEIIgjcE/tLEpBF82hiDIwCjRnEL9/hY2GJxA0T8ZvYvVVSSA==
 
 randomatic@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2864,24 +2864,6 @@ error@^7.0.0, error@^7.0.2:
     string-template "~0.2.1"
     xtend "~4.0.0"
 
-es-abstract@^1.5.1:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
-  dependencies:
-    es-to-primitive "^1.1.1"
-    function-bind "^1.1.1"
-    has "^1.0.1"
-    is-callable "^1.1.3"
-    is-regex "^1.0.4"
-
-es-to-primitive@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
-  dependencies:
-    is-callable "^1.1.1"
-    is-date-object "^1.0.1"
-    is-symbol "^1.0.1"
-
 es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.45"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.45.tgz#0bfdf7b473da5919d5adf3bd25ceb754fccc3653"
@@ -4315,10 +4297,6 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-callable@^1.1.1, is-callable@^1.1.3:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
-
 is-ci@^1.0.10:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
@@ -4336,10 +4314,6 @@ is-data-descriptor@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
   dependencies:
     kind-of "^6.0.0"
-
-is-date-object@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
 is-decimal@^1.0.0:
   version "1.0.2"
@@ -4542,12 +4516,6 @@ is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
 
-is-regex@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
-  dependencies:
-    has "^1.0.1"
-
 is-relative@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-1.0.0.tgz#a1bb6935ce8c5dba1e8b9754b9b2dcc020e2260d"
@@ -4577,10 +4545,6 @@ is-ssh@^1.3.0:
 is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-
-is-symbol@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -5967,13 +5931,6 @@ object.assign@^4.0.4, object.assign@^4.1.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
-
-object.getownpropertydescriptors@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.5.1"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -8287,13 +8244,6 @@ useragent@2.2.1:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
-util.promisify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
-  dependencies:
-    define-properties "^1.1.2"
-    object.getownpropertydescriptors "^2.0.3"
 
 util@0.10.3:
   version "0.10.3"


### PR DESCRIPTION
This changes to use quick-lru which aids IE11 compatibility because lru-cache uses Object.defineProperty on length which seems un-babel-ifiable

The util.promisify also can end up doing Object.defineProperty on the length property too so es6-promisify is used