### PR TITLE
Mate strand2

### DIFF
--- a/src/cramFile/constants.js
+++ b/src/cramFile/constants.js
@@ -8,7 +8,7 @@ module.exports = {
   // mate read is reversed
   CRAM_M_REVERSE: 1,
   // mated read is unmapped
-  CRAM_M_MAP: 2,
+  CRAM_M_UNMAP: 2,
 
   //  the read is paired in sequencing, no matter whether it is mapped in a pair
   BAM_FPAIRED: 1,

--- a/src/cramFile/constants.js
+++ b/src/cramFile/constants.js
@@ -8,7 +8,7 @@ module.exports = {
   // mate read is reversed
   CRAM_M_REVERSE: 1,
   // mated read is unmapped
-  CRAM_M_UNMAP: 2,
+  CRAM_M_MAP: 2,
 
   //  the read is paired in sequencing, no matter whether it is mapped in a pair
   BAM_FPAIRED: 1,

--- a/src/cramFile/record.js
+++ b/src/cramFile/record.js
@@ -263,7 +263,7 @@ class CramRecord {
       }
       return tmp.join('')
     }
-    return tmp;
+    return null;
   }
   /**
    * Annotates this feature with the given reference sequence basepair

--- a/src/cramFile/record.js
+++ b/src/cramFile/record.js
@@ -142,11 +142,7 @@ class CramRecord {
 
   /** @returns {boolean} true if the read itself is unmapped; conflictive with isProperlyPaired */
   isMateUnmapped() {
-    if(this.mate && undefined !== this.mate.flags) {
-      return !(this.mate.flags && Constants.CRAM_M_MAP);
-    } else {
       return !!(this.flags & Constants.BAM_FMUNMAP)
-    }
   }
 
   /** @returns {boolean} true if the read is mapped to the reverse strand */
@@ -267,7 +263,7 @@ class CramRecord {
       }
       return tmp.join('')
     }
-    return null
+    return tmp;
   }
   /**
    * Annotates this feature with the given reference sequence basepair

--- a/src/cramFile/record.js
+++ b/src/cramFile/record.js
@@ -142,7 +142,11 @@ class CramRecord {
 
   /** @returns {boolean} true if the read itself is unmapped; conflictive with isProperlyPaired */
   isMateUnmapped() {
-    return !!(this.flags & Constants.BAM_FMUNMAP)
+    if(this.mate && undefined !== this.mate.flags) {
+      return !(this.mate.flags && Constants.CRAM_M_MAP);
+    } else {
+      return !!(this.flags & Constants.BAM_FMUNMAP)
+    }
   }
 
   /** @returns {boolean} true if the read is mapped to the reverse strand */
@@ -152,7 +156,11 @@ class CramRecord {
 
   /** @returns {boolean} true if the mate is mapped to the reverse strand */
   isMateReverseComplemented() {
-    return !!(this.flags & Constants.BAM_FMREVERSE)
+    if(this.mate && undefined !== this.mate.flags) {
+      return !!(this.mate.flags && Constants.CRAM_M_REVERSE);
+    } else {
+      return !!(this.flags & Constants.BAM_FMREVERSE)
+    }
   }
 
   /** @returns {boolean} true if this is read number 1 in a pair */

--- a/src/io/remoteFile.js
+++ b/src/io/remoteFile.js
@@ -30,7 +30,7 @@ class RemoteFile {
       const nodeBuffer = Buffer.from(await response.arrayBuffer())
 
       // try to parse out the size of the remote file
-      const sizeMatch = /\/(\d+)$/.exec(response.headers.map['content-range'])
+      const sizeMatch = /\/(\d+)$/.exec(response.headers.get('content-range'))
       if (sizeMatch[1]) this._stat = { size: parseInt(sizeMatch[1], 10) }
 
       return nodeBuffer

--- a/test/1kg-mate.test.js
+++ b/test/1kg-mate.test.js
@@ -1,0 +1,44 @@
+const {expect} = require('chai')
+const {IndexedCramFile, CramFile, CraiIndex} = require('../src')
+
+describe('1kg mate test', () => {
+  describe('readme 1', () => {
+    it('runs without error', async () => {
+      const messages = []
+      const console = {
+        log(msg) {
+          messages.push(msg)
+        },
+      }
+
+      const indexedCramFile = new IndexedCramFile({
+        cram: new CramFile({
+          url: 'https://s3.amazonaws.com/1000genomes/data/HG00096/alignment/HG00096.alt_bwamem_GRCh38DH.20150718.GBR.low_coverage.cram',
+          seqFetch: async (seqId, start, end) => {
+            let fakeSeq = ''
+            for (let i = start; i <= end; i += 1) {
+              fakeSeq += 'A'
+            }
+            return fakeSeq
+          },
+          checkSequenceMD5: false
+        }),
+        index: new CraiIndex({
+          url: 'https://s3.amazonaws.com/1000genomes/data/HG00096/alignment/HG00096.alt_bwamem_GRCh38DH.20150718.GBR.low_coverage.cram.crai'
+        })
+      })
+
+      //chr8:128,749,421-128,749,582
+      const records = await indexedCramFile.getRecordsForRange(7, 128749421, 128749582)
+
+      let i=0;
+
+      const downstreamMateRecord = records.filter(rec => 'SRR062634.138050' === rec.readName)[0]
+      expect(downstreamMateRecord.isMateReverseComplemented()).to.equal(true)
+
+      const detachedMateRecord = records.filter(rec => 'SRR062635.19801940' === rec.readName)[0]
+      expect(detachedMateRecord.isMateReverseComplemented()).to.equal(true)
+
+    })
+  })
+})


### PR DESCRIPTION
Fix for mate-strand error with some 1KG files.   The BAM "reverse-mate" flag is not set in these files for "detached" (out-of-slice) mates.  However the mate.flags is set.   So in this PR we check first for mate.flags,  which is unambiguos and should always be correct.   If missing,  the BAM flag is used.   This works for the 1KG files and is an improvement, but is not completely general.   In practice this PR should handle most CRAM files in existence, however the most robust solution would be to obtain mate properties from the cram records themselves when the mate is in the same slice.   

