### PR TITLE
Mate strand fix 2

### DIFF
--- a/src/cramFile/record.js
+++ b/src/cramFile/record.js
@@ -152,7 +152,9 @@ class CramRecord {
 
   /** @returns {boolean} true if the mate is mapped to the reverse strand */
   isMateReverseComplemented() {
-    return !!(this.flags & Constants.BAM_FMREVERSE)
+    if(this.mate && this.mate.reverseComplemented !== undefined) return this.mate.reverseComplemented
+    else if(this.mate && this.mate.flags !== undefined) return !!(this.mate.flags && Constants.CRAM_M_REVERSE)
+    else return !!(this.flags & Constants.BAM_FMREVERSE)
   }
 
   /** @returns {boolean} true if this is read number 1 in a pair */

--- a/src/cramFile/slice/decodeRecord.js
+++ b/src/cramFile/slice/decodeRecord.js
@@ -3,6 +3,8 @@ const { CramMalformedError, CramUnimplementedError } = require('../../errors')
 const Long = require('long')
 
 const CramRecord = require('../record')
+const Constants = require('../constants')
+
 
 /**
  * given a Buffer, read a string up to the first null character
@@ -207,7 +209,7 @@ function decodeRecord(
     }
     mate.sequenceId = decodeDataSeries('NS')
     mate.alignmentStart = decodeDataSeries('NP')
-    if(mate.flags) mate.reverseComplemented = !!(this.mate.flags && Constants.CRAM_M_REVERSE)
+    if(mate.flags) mate.reverseComplemented = !!(mate.flags && Constants.CRAM_M_REVERSE)
     if (mate.flags || mate.sequenceId > -1) cramRecord.mate = mate
     cramRecord.templateSize = decodeDataSeries('TS')
     // detachedCount++

--- a/src/cramFile/slice/decodeRecord.js
+++ b/src/cramFile/slice/decodeRecord.js
@@ -207,6 +207,7 @@ function decodeRecord(
     }
     mate.sequenceId = decodeDataSeries('NS')
     mate.alignmentStart = decodeDataSeries('NP')
+    if(mate.flags) mate.reverseComplemented = !!(this.mate.flags && Constants.CRAM_M_REVERSE)
     if (mate.flags || mate.sequenceId > -1) cramRecord.mate = mate
     cramRecord.templateSize = decodeDataSeries('TS')
     // detachedCount++

--- a/src/cramFile/slice/index.js
+++ b/src/cramFile/slice/index.js
@@ -93,6 +93,7 @@ function associateIntraSliceMate(
     sequenceId: mateRecord.sequenceId,
     alignmentStart: mateRecord.alignmentStart,
     uniqueId: mateRecord.uniqueId,
+    reverseComplemented: mateRecord.isReverseComplemented()
   }
   if (mateRecord.readName) thisRecord.mate.readName = mateRecord.readName
 
@@ -104,6 +105,7 @@ function associateIntraSliceMate(
       sequenceId: thisRecord.sequenceId,
       alignmentStart: thisRecord.alignmentStart,
       uniqueId: thisRecord.uniqueId,
+      reverseComplemented: thisRecord.isReverseComplemented()
     }
     if (thisRecord.readName) mateRecord.mate.readName = thisRecord.readName
   }

--- a/src/io/remoteFile.js
+++ b/src/io/remoteFile.js
@@ -30,7 +30,7 @@ class RemoteFile {
       const nodeBuffer = Buffer.from(await response.arrayBuffer())
 
       // try to parse out the size of the remote file
-      const sizeMatch = /\/(\d+)$/.exec(response.headers.map['content-range'])
+      const sizeMatch = /\/(\d+)$/.exec(response.headers.get('content-range'))
       if (sizeMatch[1]) this._stat = { size: parseInt(sizeMatch[1], 10) }
 
       return nodeBuffer

--- a/test/1kg-mate.test.js
+++ b/test/1kg-mate.test.js
@@ -1,0 +1,44 @@
+const {expect} = require('chai')
+const {IndexedCramFile, CramFile, CraiIndex} = require('../src')
+
+describe('1kg mate test', () => {
+  describe('readme 1', () => {
+    it('runs without error', async () => {
+      const messages = []
+      const console = {
+        log(msg) {
+          messages.push(msg)
+        },
+      }
+
+      const indexedCramFile = new IndexedCramFile({
+        cram: new CramFile({
+          url: 'https://s3.amazonaws.com/1000genomes/data/HG00096/alignment/HG00096.alt_bwamem_GRCh38DH.20150718.GBR.low_coverage.cram',
+          seqFetch: async (seqId, start, end) => {
+            let fakeSeq = ''
+            for (let i = start; i <= end; i += 1) {
+              fakeSeq += 'A'
+            }
+            return fakeSeq
+          },
+          checkSequenceMD5: false
+        }),
+        index: new CraiIndex({
+          url: 'https://s3.amazonaws.com/1000genomes/data/HG00096/alignment/HG00096.alt_bwamem_GRCh38DH.20150718.GBR.low_coverage.cram.crai'
+        })
+      })
+
+      //chr8:128,749,421-128,749,582
+      const records = await indexedCramFile.getRecordsForRange(7, 128749421, 128749582)
+
+      let i=0;
+
+      const downstreamMateRecord = records.filter(rec => 'SRR062634.138050' === rec.readName)[0]
+      expect(downstreamMateRecord.isMateReverseComplemented()).to.equal(true)
+
+      const detachedMateRecord = records.filter(rec => 'SRR062635.19801940' === rec.readName)[0]
+      expect(detachedMateRecord.isMateReverseComplemented()).to.equal(true)
+
+    }).timeout(10000);
+  })
+})

--- a/test/1kg-mate.test.js
+++ b/test/1kg-mate.test.js
@@ -1,15 +1,9 @@
-const {expect} = require('chai')
-const {IndexedCramFile, CramFile, CraiIndex} = require('../src')
+const { expect } = require('chai')
+const { IndexedCramFile, CramFile, CraiIndex } = require('../src')
 
 describe('1kg mate test', () => {
   describe('readme 1', () => {
     it('runs without error', async () => {
-      const messages = []
-      const console = {
-        log(msg) {
-          messages.push(msg)
-        },
-      }
 
       const indexedCramFile = new IndexedCramFile({
         cram: new CramFile({
@@ -24,21 +18,25 @@ describe('1kg mate test', () => {
           checkSequenceMD5: false
         }),
         index: new CraiIndex({
-          url: 'https://s3.amazonaws.com/1000genomes/data/HG00096/alignment/HG00096.alt_bwamem_GRCh38DH.20150718.GBR.low_coverage.cram.crai'
+          url: 'https://s3.amazonaws.com/1000genomes/data/HG00096/alignment/HG00096.alt_bwamem_GRCh38DH.20150718.GBR.low_coverage.cram.crai',
         })
       })
 
-      //chr8:128,749,421-128,749,582
+      // chr8:128,749,421-128,749,582
       const records = await indexedCramFile.getRecordsForRange(7, 128749421, 128749582)
 
-      let i=0;
+      const downstreamMateRecord = records.filter(
+        rec => 'SRR062634.138050' === rec.readName
+      )[0]
 
-      const downstreamMateRecord = records.filter(rec => 'SRR062634.138050' === rec.readName)[0]
       expect(downstreamMateRecord.isMateReverseComplemented()).to.equal(true)
 
-      const detachedMateRecord = records.filter(rec => 'SRR062635.19801940' === rec.readName)[0]
+      const detachedMateRecord = records.filter(
+        rec => 'SRR062635.19801940' === rec.readName
+      )[0]
+
       expect(detachedMateRecord.isMateReverseComplemented()).to.equal(true)
 
-    }).timeout(10000);
+    }).timeout(10000)
   })
 })


### PR DESCRIPTION
Second iteration of mate strand fix.  This uses the actual cram records, as implied in the spec.  