### PR TITLE
Fix CRAM not downloading proper records for long read example

### DIFF
--- a/src/craiIndex.js
+++ b/src/craiIndex.js
@@ -154,12 +154,10 @@ class CraiIndex {
    */
   async getEntriesForRange(seqId, queryStart, queryEnd) {
     const seqEntries = (await this.getIndex())[seqId]
-    if (!seqEntries) return []
-    const len = seqEntries.length
+    if (!seqEntries) {
+      return []
+    }
 
-    // binary search to find an entry that
-    // overlaps the range, then extend backward
-    // and forward from that
     const compare = entry => {
       const entryStart = entry.start
       const entryEnd = entry.start + entry.span
@@ -167,39 +165,13 @@ class CraiIndex {
       if (entryEnd <= queryStart) return 1 // entry is behind query
       return 0 // entry overlaps query
     }
-
-    let lowerBound = 0
-    let upperBound = len - 1
-    let searchPosition
-    while (lowerBound <= upperBound) {
-      searchPosition = Math.floor((upperBound + lowerBound) / 2)
-      const nextSearchDirection = compare(seqEntries[searchPosition])
-      if (nextSearchDirection > 0) {
-        lowerBound = searchPosition + 1
-      } else if (nextSearchDirection < 0) {
-        upperBound = searchPosition - 1
-      } else {
-        break
+    const bins = []
+    for (let i = 0; i < seqEntries.length; i += 1) {
+      if (compare(seqEntries[i]) === 0) {
+        bins.push(seqEntries[i])
       }
     }
-
-    // now extend backward
-    let overlapStart = searchPosition
-    while (overlapStart && !compare(seqEntries[overlapStart - 1]))
-      overlapStart -= 1
-    // and then extend forward
-    let overlapEnd = searchPosition
-    while (overlapEnd < len - 1 && !compare(seqEntries[overlapEnd + 1]))
-      overlapEnd += 1
-
-    const x1 = seqEntries[overlapStart].start
-    const x2 = seqEntries[overlapEnd].start + seqEntries[overlapEnd].span
-    const y1 = queryStart
-    const y2 = queryEnd
-    if (x2 >= y1 && y2 >= x1) {
-      return seqEntries.slice(overlapStart, overlapEnd + 1)
-    }
-    return []
+    return bins
   }
 }
 

--- a/test/indexedfile.test.js
+++ b/test/indexedfile.test.js
@@ -368,10 +368,9 @@ describe('region not downloading enough records', () => {
       ),
     })
     const entries = await index.getEntriesForRange(0, 75100635, 75125544)
-    // hard coded based on expected response, previously was returning the 283
-    // bin but now returns 285 bin after PR #85
-    expect(entries.length).to.equal(1)
-    expect(entries[0].start).to.equal(74945118)
+    expect(entries.length).to.equal(2)
+    expect(entries[0].start).to.equal(74378949)
+    expect(entries[1].start).to.equal(74945118)
   })
 })
 


### PR DESCRIPTION
I found in certain regions that CRAM records were not getting downloaded properly

I suspected the index just as a first inkling and I think it is the case that our "binary search" approach is not valid

https://github.com/GMOD/jbrowse-components/issues/1654

In this version the bins that are pushed are

283
285

In the version on master the code produces

seqEntries.slice(283,284)

I believe this is evidence that we need to grab discontinuous bins

Why we see this now with the long read example is perhaps that a very long read in 283 overlaps with the slice from 285 (not exactly sure)

After this change, the region in jb2 issue https://github.com/GMOD/jbrowse-components/issues/1654 renders properly

![localhost_3000__config=test_data%2Fconfig_demo json%3Fconfig%3Dtest_data%2Fconfig_demo json session=local-GrwYyBEng](https://user-images.githubusercontent.com/6511937/108808854-cf4c5e00-7564-11eb-99b5-9d6af343aebc.png)
