### PR TITLE
Use pako instead of zlib

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@gmod/indexedfasta": "^2.0.2",
     "@types/jest": "^27.4.0",
+    "@types/pako": "^1.0.3",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",
     "documentation": "^13.2.5",
@@ -77,6 +78,8 @@
   },
   "browser": {
     "./dist/io/localFile.js": false,
-    "./esm/io/localFile.js": false
+    "./esm/io/localFile.js": false,
+    "./esm/unzip.js": "./esm/unzip-pako.js",
+    "./dist/unzip.js": "./dist/unzip-pako.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "es6-promisify": "^6.0.1",
     "long": "^4.0.0",
     "md5": "^2.2.1",
+    "pako": "^1.0.4",
     "quick-lru": "^2.0.0"
   },
   "devDependencies": {

--- a/src/craiIndex.js
+++ b/src/craiIndex.js
@@ -1,11 +1,8 @@
 import AbortablePromiseCache from 'abortable-promise-cache'
 import QuickLRU from 'quick-lru'
-import { promisify } from 'es6-promisify'
-import zlib from 'zlib'
+import { inflate } from 'pako'
 import { open } from './io'
 import { CramMalformedError } from './errors'
-
-const gunzip = promisify(zlib.gunzip)
 
 const BAI_MAGIC = 21578050 // BAI\1
 
@@ -72,7 +69,7 @@ export default class CraiIndex {
     return this.readFile()
       .then(data => {
         if (data[0] === 31 && data[1] === 139) {
-          return gunzip(data)
+          return Buffer.from(inflate(data))
         }
         return data
       })

--- a/src/craiIndex.js
+++ b/src/craiIndex.js
@@ -1,6 +1,6 @@
 import AbortablePromiseCache from 'abortable-promise-cache'
 import QuickLRU from 'quick-lru'
-import { inflate } from 'pako'
+import { unzip } from './unzip'
 import { open } from './io'
 import { CramMalformedError } from './errors'
 
@@ -69,7 +69,7 @@ export default class CraiIndex {
     return this.readFile()
       .then(data => {
         if (data[0] === 31 && data[1] === 139) {
-          return Buffer.from(inflate(data))
+          return unzip(data)
         }
         return data
       })

--- a/src/cramFile/file.js
+++ b/src/cramFile/file.js
@@ -1,4 +1,4 @@
-import { inflate } from 'pako'
+import { unzip } from '../unzip'
 import crc32 from 'buffer-crc32'
 import LRU from 'quick-lru'
 
@@ -244,7 +244,7 @@ export default class CramFile {
 
   _uncompress(compressionMethod, inputBuffer, outputBuffer) {
     if (compressionMethod === 'gzip') {
-      const result = Buffer.from(inflate(inputBuffer))
+      const result = unzip(inputBuffer)
       result.copy(outputBuffer)
     } else if (compressionMethod === 'bzip2') {
       var bits = bzip2.array(inputBuffer)

--- a/src/cramFile/file.js
+++ b/src/cramFile/file.js
@@ -1,4 +1,4 @@
-import zlib from 'zlib'
+import { inflate } from 'pako'
 import crc32 from 'buffer-crc32'
 import LRU from 'quick-lru'
 
@@ -244,7 +244,7 @@ export default class CramFile {
 
   _uncompress(compressionMethod, inputBuffer, outputBuffer) {
     if (compressionMethod === 'gzip') {
-      const result = zlib.gunzipSync(inputBuffer)
+      const result = Buffer.from(inflate(inputBuffer))
       result.copy(outputBuffer)
     } else if (compressionMethod === 'bzip2') {
       var bits = bzip2.array(inputBuffer)

--- a/src/unzip-pako.ts
+++ b/src/unzip-pako.ts
@@ -1,0 +1,5 @@
+import { inflate } from 'pako'
+
+export function unzip(input: Buffer) {
+  return Buffer.from(inflate(input))
+}

--- a/src/unzip.ts
+++ b/src/unzip.ts
@@ -1,0 +1,2 @@
+import { gunzipSync } from 'zlib'
+export { gunzipSync as unzip }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5733,7 +5733,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-pako@^1.0.11, pako@~1.0.5:
+pako@^1.0.11, pako@^1.0.4, pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,6 +684,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@types/pako@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/pako/-/pako-1.0.3.tgz#2e61c2b02020b5f44e2e5e946dfac74f4ec33c58"
+  integrity sha512-EDxOsHAD5dqjbjEUM1xwa7rpKPFb8ECBE5irONTQU7/OsO3thI5YrNEWSPNMvYmvFM0l/OLQJ6Mgw7PEdXSjhg==
+
 "@types/prettier@^2.1.5":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.3.tgz#a3c65525b91fca7da00ab1a3ac2b5a2a4afbffbf"


### PR DESCRIPTION
There is increasing trend to not having polyfills on the web included by default, and some zlib polyfills are broken for cram purposes https://github.com/GMOD/jbrowse-components/issues/2722

This explicitly uses pako to try to help fix this