### PR TITLE
Small optimization

### DIFF
--- a/src/cramFile/codecs/byteArrayLength.js
+++ b/src/cramFile/codecs/byteArrayLength.js
@@ -23,7 +23,7 @@ export default class ByteArrayStopCodec extends CramCodec {
     )
 
     const dataCodec = this._getDataCodec()
-    const data = new Array(arrayLength)
+    const data = new Uint8Array(arrayLength)
     for (let i = 0; i < arrayLength; i += 1) {
       data[i] = dataCodec.decode(
         slice,

--- a/src/cramFile/codecs/byteArrayStop.js
+++ b/src/cramFile/codecs/byteArrayStop.js
@@ -44,7 +44,6 @@ export default class ByteArrayStopCodec extends CramCodec {
       stopPosition += 1
     }
     cursor.bytePosition = stopPosition + 1
-    const data = dataBuffer.slice(startPosition, stopPosition)
-    return data
+    return dataBuffer.slice(startPosition, stopPosition)
   }
 }

--- a/src/cramFile/codecs/external.js
+++ b/src/cramFile/codecs/external.js
@@ -47,8 +47,6 @@ export default class ExternalCodec extends CramCodec {
         'attempted to read beyond end of block. this file seems truncated.',
       )
     }
-    const result = contentBlock.content[cursor.bytePosition]
-    cursor.bytePosition += 1
-    return result
+    return contentBlock.content[cursor.bytePosition++]
   }
 }

--- a/src/cramFile/container/compressionScheme.js
+++ b/src/cramFile/container/compressionScheme.js
@@ -82,7 +82,7 @@ export default class CramContainerCompressionScheme {
     this.tagIdsDictionary = content.preservation.TD
     this.substitutionMatrix = parseSubstitutionMatrix(content.preservation.SM)
 
-    this.dataSeriesCodecCache = {}
+    this.dataSeriesCodecCache = new Map()
     this.tagCodecCache = {}
   }
 
@@ -113,7 +113,8 @@ export default class CramContainerCompressionScheme {
   }
 
   getCodecForDataSeries(dataSeriesName) {
-    if (!this.dataSeriesCodecCache[dataSeriesName]) {
+    let r = this.dataSeriesCodecCache.get(dataSeriesName)
+    if (r === undefined) {
       const encodingData = this.dataSeriesEncoding[dataSeriesName]
       if (encodingData) {
         const dataType = dataSeriesTypes[dataSeriesName]
@@ -122,13 +123,11 @@ export default class CramContainerCompressionScheme {
             `data series name ${dataSeriesName} not defined in file compression header`,
           )
         }
-        this.dataSeriesCodecCache[dataSeriesName] = instantiateCodec(
-          encodingData,
-          dataType,
-        )
+        r = instantiateCodec(encodingData, dataType)
+        this.dataSeriesCodecCache.set(dataSeriesName, r)
       }
     }
-    return this.dataSeriesCodecCache[dataSeriesName]
+    return r
   }
 
   toJSON() {

--- a/src/cramFile/file.js
+++ b/src/cramFile/file.js
@@ -14,6 +14,19 @@ import CramContainer from './container'
 import { open } from '../io'
 import { parseItem, tinyMemoize } from './util'
 import { parseHeaderText } from '../sam'
+//source:https://abdulapopoola.com/2019/01/20/check-endianness-with-javascript/
+function getEndianness() {
+  let uInt32 = new Uint32Array([0x11223344])
+  let uInt8 = new Uint8Array(uInt32.buffer)
+
+  if (uInt8[0] === 0x44) {
+    return 0 //little-endian
+  } else if (uInt8[0] === 0x11) {
+    return 1 //big-endian
+  } else {
+    return 2 //mixed-endian?
+  }
+}
 
 export default class CramFile {
   /**
@@ -44,6 +57,9 @@ export default class CramFile {
     this.featureCache = new LRU({
       maxSize: this.options.cacheSize,
     })
+    if (getEndianness() > 0) {
+      console.warn('Detected big-endian machine, may not be able to run')
+    }
   }
 
   toString() {

--- a/src/cramFile/file.js
+++ b/src/cramFile/file.js
@@ -58,7 +58,7 @@ export default class CramFile {
       maxSize: this.options.cacheSize,
     })
     if (getEndianness() > 0) {
-      console.warn('Detected big-endian machine, may not be able to run')
+      throw new Error('Detected big-endian machine, may be unable to run')
     }
   }
 

--- a/src/cramFile/slice/decodeRecord.js
+++ b/src/cramFile/slice/decodeRecord.js
@@ -6,12 +6,12 @@ import Constants from '../constants'
  * given a Buffer, read a string up to the first null character
  * @private
  */
-function readNullTerminatedStringFromBuffer(buffer) {
-  const zeroOffset = buffer.indexOf(0)
-  if (zeroOffset === -1) {
-    return buffer.toString('utf8')
+function readString(buffer) {
+  let r = ''
+  for (let i = 0; i < buffer.length && buffer[i] !== 0; i++) {
+    r += String.fromCharCode(buffer[i])
   }
-  return buffer.toString('utf8', 0, zeroOffset)
+  return r
 }
 
 /**
@@ -20,72 +20,82 @@ function readNullTerminatedStringFromBuffer(buffer) {
  */
 function parseTagValueArray(buffer) {
   const arrayType = String.fromCharCode(buffer[0])
-  const length = buffer.readInt32LE(1)
+  const length = Int32Array.from(buffer.slice(1))[0]
 
-  const schema = {
-    c: ['readInt8', 1],
-    C: ['readUInt8', 1],
-    s: ['readInt16LE', 2],
-    S: ['readUInt16LE', 2],
-    i: ['readInt32LE', 4],
-    I: ['readUInt32LE', 4],
-    f: ['readFloatLE', 4],
-  }[arrayType]
-  if (!schema) {
-    throw new CramMalformedError(`invalid tag value array type '${arrayType}'`)
-  }
-
-  const [getMethod, itemSize] = schema
   const array = new Array(length)
-  let offset = 5
-  for (let i = 0; i < length; i += 1) {
-    array[i] = buffer[getMethod](offset)
-    offset += itemSize
+  buffer = buffer.slice(5)
+
+  if (arrayType === 'c') {
+    const arr = new Int8Array(buffer.buffer)
+    for (let i = 0; i < length; i += 1) {
+      array[i] = arr[i]
+    }
+  } else if (arrayType === 'C') {
+    const arr = new Uint8Array(buffer.buffer)
+    for (let i = 0; i < length; i += 1) {
+      array[i] = arr[i]
+    }
+  } else if (arrayType === 's') {
+    const arr = new Int16Array(buffer.buffer)
+    for (let i = 0; i < length; i += 1) {
+      array[i] = arr[i]
+    }
+  } else if (arrayType === 'S') {
+    const arr = new Uint16Array(buffer.buffer)
+    for (let i = 0; i < length; i += 1) {
+      array[i] = arr[i]
+    }
+  } else if (arrayType === 'i') {
+    const arr = new Int32Array(buffer.buffer)
+    for (let i = 0; i < length; i += 1) {
+      array[i] = arr[i]
+    }
+  } else if (arrayType === 'I') {
+    const arr = new Uint32Array(buffer.buffer)
+    for (let i = 0; i < length; i += 1) {
+      array[i] = arr[i]
+    }
+  } else if (arrayType === 'f') {
+    const arr = new Float32Array(buffer.buffer)
+    for (let i = 0; i < length; i += 1) {
+      array[i] = arr[i]
+    }
+  } else {
+    throw new Error('unknown type: ' + arrayType)
   }
+
   return array
 }
-
 function parseTagData(tagType, buffer) {
-  if (!buffer.readInt32LE) {
-    buffer = Buffer.from(buffer)
-  }
   if (tagType === 'Z') {
-    return readNullTerminatedStringFromBuffer(buffer)
+    return readString(buffer)
   }
   if (tagType === 'A') {
     return String.fromCharCode(buffer[0])
   }
   if (tagType === 'I') {
-    const val = Long.fromBytesLE(buffer)
-    if (
-      val.greaterThan(Number.MAX_SAFE_INTEGER) ||
-      val.lessThan(Number.MIN_SAFE_INTEGER)
-    ) {
-      throw new CramUnimplementedError('integer overflow')
-    }
-    return val.toNumber()
+    return Long.fromBytesLE(buffer).toNumber()
   }
   if (tagType === 'i') {
-    return buffer.readInt32LE(0)
+    return new Int32Array(buffer.buffer)[0]
   }
   if (tagType === 's') {
-    return buffer.readInt16LE(0)
+    return new Int16Array(buffer.buffer)[0]
   }
   if (tagType === 'S') {
-    return buffer.readUInt16LE(0)
+    return new Uint16Array(buffer.buffer)[0]
   }
   if (tagType === 'c') {
-    return buffer.readInt8(0)
+    return new Int8Array(buffer.buffer)[0]
   }
   if (tagType === 'C') {
-    return buffer.readUInt8(0)
+    return buffer[0]
   }
   if (tagType === 'f') {
-    return buffer.readFloatLE(0)
+    return new Float32Array(buffer.buffer)[0]
   }
   if (tagType === 'H') {
-    const hex = readNullTerminatedStringFromBuffer(buffer)
-    return Number.parseInt(hex.replace(/^0x/, ''), 16)
+    return Number.parseInt(readString(buffer).replace(/^0x/, ''), 16)
   }
   if (tagType === 'B') {
     return parseTagValueArray(buffer)
@@ -176,22 +186,6 @@ function decodeReadFeatures(
   return readFeatures
 }
 
-function thingToString(thing) {
-  if (thing instanceof Buffer) {
-    return readNullTerminatedStringFromBuffer(thing)
-  }
-  if (thing.length && thing.indexOf) {
-    // array-like
-    if (!thing[thing.length - 1]) {
-      // trim zeroes off the end if necessary
-      const termIndex = thing.indexOf(0)
-      return String.fromCharCode(...thing.slice(0, termIndex))
-    }
-    return String.fromCharCode(...thing)
-  }
-  return String(thing)
-}
-
 export default function decodeRecord(
   slice,
   decodeDataSeries,
@@ -228,7 +222,7 @@ export default function decodeRecord(
   cramRecord.readGroupId = decodeDataSeries('RG')
 
   if (compressionScheme.readNamesIncluded) {
-    cramRecord.readName = thingToString(decodeDataSeries('RN'))
+    cramRecord.readName = readString(decodeDataSeries('RN'))
   }
 
   // mate record
@@ -237,7 +231,7 @@ export default function decodeRecord(
     const mate = {}
     mate.flags = decodeDataSeries('MF')
     if (!compressionScheme.readNamesIncluded) {
-      mate.readName = thingToString(decodeDataSeries('RN'))
+      mate.readName = readString(decodeDataSeries('RN'))
       cramRecord.readName = mate.readName
     }
     mate.sequenceId = decodeDataSeries('NS')

--- a/src/cramFile/slice/index.js
+++ b/src/cramFile/slice/index.js
@@ -336,18 +336,22 @@ export default class CramSlice {
     }
 
     // tracks the read position within the block. codec.decode() methods
-    // advance the byte and bit positions in the cursor as they decode data
-    // note that we are only decoding a single block here, the core data block
+    // advance the byte and bit positions in the cursor as they decode
+    // data note that we are only decoding a single block here, the core
+    // data block
     const coreDataBlock = await this.getCoreDataBlock()
     const cursors = {
       lastAlignmentStart: sliceHeader.content.refSeqStart || 0,
       coreBlock: { bitPosition: 7, bytePosition: 0 },
       externalBlocks: {
+        map: new Map(),
         getCursor(contentId) {
-          if (!this[contentId]) {
-            this[contentId] = { bitPosition: 7, bytePosition: 0 }
+          let r = this.map.get(contentId)
+          if (r === undefined) {
+            r = { bitPosition: 7, bytePosition: 0 }
+            this.map.set(contentId, r)
           }
-          return this[contentId]
+          return r
         },
       },
     }
@@ -394,8 +398,8 @@ export default class CramSlice {
       }
     }
 
-    // interpret `recordsToNextFragment` attributes to make standard `mate` objects
-    // Resolve mate pair cross-references between records in this slice
+    // interpret `recordsToNextFragment` attributes to make standard `mate`
+    // objects Resolve mate pair cross-references between records in this slice
     for (let i = 0; i < records.length; i += 1) {
       const { mateRecordNumber } = records[i]
       if (mateRecordNumber >= 0) {


### PR DESCRIPTION
This PR makes cram parsing about 15% faster on shortread tests in the jb2profile suite, about 5-10% for longreads (that is for the end-to-end, so to make the entire test 15% faster, the cram parsing portion speedup could be greater 15% for example)


so, with 20x, 200x, 400x, 600x, 800x, 1000x shortreads

```
0.02 cram 20x
./profile.sh chr22_mask:124,000-134,000 20x.shortread.cram results/20x-shortread-cram hg19mod
Benchmark 1: node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=20x.shortread.cram" "results/20x-shortread-cram_fps_8001.json" "results/20x-shortread-cram_mem_8001.json"
  Time (mean ± σ):      4.799 s ±  0.095 s    [User: 0.447 s, System: 0.154 s]
  Range (min … max):    4.681 s …  4.940 s    5 runs

Benchmark 2: node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=20x.shortread.cram" "results/20x-shortread-cram_fps_8004.json" "results/20x-shortread-cram_mem_8004.json"
  Time (mean ± σ):      4.328 s ±  0.055 s    [User: 0.434 s, System: 0.124 s]
  Range (min … max):    4.248 s …  4.391 s    5 runs

Summary
  'node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=20x.shortread.cram" "results/20x-shortread-cram_fps_8004.json" "results/20x-shortread-cram_mem_8004.json"' ran
    1.11 ± 0.03 times faster than 'node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=20x.shortread.cram" "results/20x-shortread-cram_fps_8001.json" "results/20x-shortread-cram_mem_8001.json"'








0.20 cram 200x
./profile.sh chr22_mask:124,000-134,000 200x.shortread.cram results/200x-shortread-cram hg19mod
Benchmark 1: node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=200x.shortread.cram" "results/200x-shortread-cram_fps_8001.json" "results/200x-shortread-cram_mem_8001.json"
  Time (mean ± σ):     10.395 s ±  0.295 s    [User: 0.515 s, System: 0.164 s]
  Range (min … max):   10.027 s … 10.751 s    5 runs

Benchmark 2: node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=200x.shortread.cram" "results/200x-shortread-cram_fps_8004.json" "results/200x-shortread-cram_mem_8004.json"
  Time (mean ± σ):      9.222 s ±  0.273 s    [User: 0.539 s, System: 0.149 s]
  Range (min … max):    8.839 s …  9.568 s    5 runs

Summary
  'node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=200x.shortread.cram" "results/200x-shortread-cram_fps_8004.json" "results/200x-shortread-cram_mem_8004.json"' ran
    1.13 ± 0.05 times faster than 'node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=200x.shortread.cram" "results/200x-shortread-cram_fps_8001.json" "results/200x-shortread-cram_mem_8001.json"'








0.40 cram 400x
./profile.sh chr22_mask:124,000-134,000 400x.shortread.cram results/400x-shortread-cram hg19mod
Benchmark 1: node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=400x.shortread.cram" "results/400x-shortread-cram_fps_8001.json" "results/400x-shortread-cram_mem_8001.json"
  Time (mean ± σ):     15.666 s ±  0.331 s    [User: 0.576 s, System: 0.171 s]
  Range (min … max):   15.191 s … 16.003 s    5 runs

Benchmark 2: node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=400x.shortread.cram" "results/400x-shortread-cram_fps_8004.json" "results/400x-shortread-cram_mem_8004.json"
  Time (mean ± σ):     14.011 s ±  0.214 s    [User: 0.595 s, System: 0.180 s]
  Range (min … max):   13.667 s … 14.228 s    5 runs

Summary
  'node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=400x.shortread.cram" "results/400x-shortread-cram_fps_8004.json" "results/400x-shortread-cram_mem_8004.json"' ran
    1.12 ± 0.03 times faster than 'node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=400x.shortread.cram" "results/400x-shortread-cram_fps_8001.json" "results/400x-shortread-cram_mem_8001.json"'








0.60 cram 600x
./profile.sh chr22_mask:124,000-134,000 600x.shortread.cram results/600x-shortread-cram hg19mod
Benchmark 1: node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=600x.shortread.cram" "results/600x-shortread-cram_fps_8001.json" "results/600x-shortread-cram_mem_8001.json"
  Time (mean ± σ):     22.709 s ±  0.814 s    [User: 0.619 s, System: 0.185 s]
  Range (min … max):   21.791 s … 23.768 s    5 runs

Benchmark 2: node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=600x.shortread.cram" "results/600x-shortread-cram_fps_8004.json" "results/600x-shortread-cram_mem_8004.json"
  Time (mean ± σ):     19.108 s ±  1.368 s    [User: 0.600 s, System: 0.177 s]
  Range (min … max):   18.061 s … 21.442 s    5 runs

Summary
  'node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=600x.shortread.cram" "results/600x-shortread-cram_fps_8004.json" "results/600x-shortread-cram_mem_8004.json"' ran
    1.19 ± 0.10 times faster than 'node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=600x.shortread.cram" "results/600x-shortread-cram_fps_8001.json" "results/600x-shortread-cram_mem_8001.json"'








0.80 cram 800x
./profile.sh chr22_mask:124,000-134,000 800x.shortread.cram results/800x-shortread-cram hg19mod
Benchmark 1: node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=800x.shortread.cram" "results/800x-shortread-cram_fps_8001.json" "results/800x-shortread-cram_mem_8001.json"
  Time (mean ± σ):     27.237 s ±  1.082 s    [User: 0.605 s, System: 0.207 s]
  Range (min … max):   26.263 s … 28.928 s    5 runs

Benchmark 2: node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=800x.shortread.cram" "results/800x-shortread-cram_fps_8004.json" "results/800x-shortread-cram_mem_8004.json"
  Time (mean ± σ):     24.159 s ±  1.293 s    [User: 0.613 s, System: 0.206 s]
  Range (min … max):   22.766 s … 25.636 s    5 runs

Summary
  'node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=800x.shortread.cram" "results/800x-shortread-cram_fps_8004.json" "results/800x-shortread-cram_mem_8004.json"' ran
    1.13 ± 0.08 times faster than 'node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=800x.shortread.cram" "results/800x-shortread-cram_fps_8001.json" "results/800x-shortread-cram_mem_8001.json"'








1 cram 1000x
./profile.sh chr22_mask:124,000-134,000 1000x.shortread.cram results/1000x-shortread-cram hg19mod
Benchmark 1: node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=1000x.shortread.cram" "results/1000x-shortread-cram_fps_8001.json" "results/1000x-shortread-cram_mem_8001.json"
  Time (mean ± σ):     32.612 s ±  0.891 s    [User: 0.692 s, System: 0.200 s]
  Range (min … max):   31.645 s … 33.536 s    5 runs

Benchmark 2: node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=1000x.shortread.cram" "results/1000x-shortread-cram_fps_8004.json" "results/1000x-shortread-cram_mem_8004.json"
  Time (mean ± σ):     28.240 s ±  1.316 s    [User: 0.699 s, System: 0.221 s]
  Range (min … max):   26.232 s … 29.876 s    5 runs

Summary
  'node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=1000x.shortread.cram" "results/1000x-shortread-cram_fps_8004.json" "results/1000x-shortread-cram_mem_8004.json"' ran
    1.15 ± 0.06 times faster than 'node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=1000x.shortread.cram" "results/1000x-shortread-cram_fps_8001.json" "results/1000x-shortread-cram_mem_8001.json"'




```


with longreads
```
0.02 cram 20x
./profile.sh chr22_mask:124,000-134,000 20x.longread.cram results/20x-longread-cram hg19mod
Benchmark 1: node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=20x.longread.cram" "results/20x-longread-cram_fps_8001.json" "results/20x-longread-cram_mem_8001.json"
  Time (mean ± σ):      5.744 s ±  0.045 s    [User: 0.451 s, System: 0.163 s]
  Range (min … max):    5.675 s …  5.796 s    5 runs

Benchmark 2: node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=20x.longread.cram" "results/20x-longread-cram_fps_8004.json" "results/20x-longread-cram_mem_8004.json"
  Time (mean ± σ):      5.516 s ±  0.063 s    [User: 0.456 s, System: 0.184 s]
  Range (min … max):    5.404 s …  5.556 s    5 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Summary
  'node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=20x.longread.cram" "results/20x-longread-cram_fps_8004.json" "results/20x-longread-cram_mem_8004.json"' ran
    1.04 ± 0.01 times faster than 'node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=20x.longread.cram" "results/20x-longread-cram_fps_8001.json" "results/20x-longread-cram_mem_8001.json"'








0.20 cram 200x
./profile.sh chr22_mask:124,000-134,000 200x.longread.cram results/200x-longread-cram hg19mod
Benchmark 1: node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=200x.longread.cram" "results/200x-longread-cram_fps_8001.json" "results/200x-longread-cram_mem_8001.json"
  Time (mean ± σ):     16.081 s ±  0.159 s    [User: 0.597 s, System: 0.230 s]
  Range (min … max):   15.876 s … 16.256 s    5 runs

Benchmark 2: node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=200x.longread.cram" "results/200x-longread-cram_fps_8004.json" "results/200x-longread-cram_mem_8004.json"
  Time (mean ± σ):     15.331 s ±  0.416 s    [User: 0.556 s, System: 0.213 s]
  Range (min … max):   14.690 s … 15.686 s    5 runs

Summary
  'node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=200x.longread.cram" "results/200x-longread-cram_fps_8004.json" "results/200x-longread-cram_mem_8004.json"' ran
    1.05 ± 0.03 times faster than 'node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=200x.longread.cram" "results/200x-longread-cram_fps_8001.json" "results/200x-longread-cram_mem_8001.json"'








0.40 cram 400x
./profile.sh chr22_mask:124,000-134,000 400x.longread.cram results/400x-longread-cram hg19mod
Benchmark 1: node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=400x.longread.cram" "results/400x-longread-cram_fps_8001.json" "results/400x-longread-cram_mem_8001.json"
  Time (mean ± σ):     26.073 s ±  1.061 s    [User: 0.607 s, System: 0.248 s]
  Range (min … max):   25.075 s … 27.643 s    5 runs

Benchmark 2: node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=400x.longread.cram" "results/400x-longread-cram_fps_8004.json" "results/400x-longread-cram_mem_8004.json"
  Time (mean ± σ):     24.245 s ±  0.830 s    [User: 0.608 s, System: 0.217 s]
  Range (min … max):   23.003 s … 25.156 s    5 runs

Summary
  'node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=400x.longread.cram" "results/400x-longread-cram_fps_8004.json" "results/400x-longread-cram_mem_8004.json"' ran
    1.08 ± 0.06 times faster than 'node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=400x.longread.cram" "results/400x-longread-cram_fps_8001.json" "results/400x-longread-cram_mem_8001.json"'








0.60 cram 600x
./profile.sh chr22_mask:124,000-134,000 600x.longread.cram results/600x-longread-cram hg19mod
Benchmark 1: node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=600x.longread.cram" "results/600x-longread-cram_fps_8001.json" "results/600x-longread-cram_mem_8001.json"
  Time (mean ± σ):     36.082 s ±  0.906 s    [User: 0.651 s, System: 0.277 s]
  Range (min … max):   35.126 s … 37.209 s    5 runs

Benchmark 2: node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=600x.longread.cram" "results/600x-longread-cram_fps_8004.json" "results/600x-longread-cram_mem_8004.json"
  Time (mean ± σ):     33.503 s ±  0.752 s    [User: 0.673 s, System: 0.268 s]
  Range (min … max):   32.387 s … 34.415 s    5 runs

Summary
  'node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=600x.longread.cram" "results/600x-longread-cram_fps_8004.json" "results/600x-longread-cram_mem_8004.json"' ran
    1.08 ± 0.04 times faster than 'node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=600x.longread.cram" "results/600x-longread-cram_fps_8001.json" "results/600x-longread-cram_mem_8001.json"'








0.80 cram 800x
./profile.sh chr22_mask:124,000-134,000 800x.longread.cram results/800x-longread-cram hg19mod
Benchmark 1: node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=800x.longread.cram" "results/800x-longread-cram_fps_8001.json" "results/800x-longread-cram_mem_8001.json"
  Time (mean ± σ):     47.426 s ±  0.659 s    [User: 0.708 s, System: 0.325 s]
  Range (min … max):   46.572 s … 48.385 s    5 runs

Benchmark 2: node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=800x.longread.cram" "results/800x-longread-cram_fps_8004.json" "results/800x-longread-cram_mem_8004.json"
  Time (mean ± σ):     41.976 s ±  1.387 s    [User: 0.748 s, System: 0.286 s]
  Range (min … max):   40.099 s … 43.651 s    5 runs

Summary
  'node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=800x.longread.cram" "results/800x-longread-cram_fps_8004.json" "results/800x-longread-cram_mem_8004.json"' ran
    1.13 ± 0.04 times faster than 'node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=800x.longread.cram" "results/800x-longread-cram_fps_8001.json" "results/800x-longread-cram_mem_8001.json"'








1 cram 1000x
./profile.sh chr22_mask:124,000-134,000 1000x.longread.cram results/1000x-longread-cram hg19mod
Benchmark 1: node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=1000x.longread.cram" "results/1000x-longread-cram_fps_8001.json" "results/1000x-longread-cram_mem_8001.json"
  Time (mean ± σ):     54.793 s ±  1.275 s    [User: 0.764 s, System: 0.330 s]
  Range (min … max):   53.128 s … 56.579 s    5 runs

Benchmark 2: node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=1000x.longread.cram" "results/1000x-longread-cram_fps_8004.json" "results/1000x-longread-cram_mem_8004.json"
  Time (mean ± σ):     50.722 s ±  0.674 s    [User: 0.761 s, System: 0.345 s]
  Range (min … max):   49.779 s … 51.536 s    5 runs

Summary
  'node profile_jb2web.js "http://localhost:8004/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=1000x.longread.cram" "results/1000x-longread-cram_fps_8004.json" "results/1000x-longread-cram_mem_8004.json"' ran
    1.08 ± 0.03 times faster than 'node profile_jb2web.js "http://localhost:8001/?loc=chr22_mask:124,000-134,000&assembly=hg19mod&tracks=1000x.longread.cram" "results/1000x-longread-cram_fps_8001.json" "results/1000x-longread-cram_mem_8001.json"'




```

overall, not a gigantic speedup but could maybe get more over time. note: uses typedarrays primarily instead of buffer. this typedarray usage may not work on a bigendian machines (typedarray uses native endianness), but big endian machines are exceedingly rare.