### PR TITLE
Remove extended tests

### DIFF
--- a/test/indexedfile.test.ts
+++ b/test/indexedfile.test.ts
@@ -2,7 +2,6 @@
 import {
   testDataFile,
   loadTestJSON,
-  extended,
   JsonClone,
   REWRITE_EXPECTED_DATA,
   fs,
@@ -202,54 +201,6 @@ describe('.crai indexed cram file', () => {
       )
     })
   })
-
-  extended(
-    'can fetch some regions of tomato example data correctly',
-    async () => {
-      // const fasta = new IndexedFastaFile({
-      //   fasta: testDataFile('extended/S_lycopersicum_chromosomes.2.50.fa'),
-      //   fai: testDataFile('extended/S_lycopersicum_chromosomes.2.50.fa.fai'),
-      // })
-      const cram = new IndexedCramFile({
-        cramFilehandle: testDataFile('extended/RNAseq_mapping_def.cram'),
-        index: new CraiIndex({
-          filehandle: testDataFile('extended/RNAseq_mapping_def.cram.crai'),
-        }),
-        // seqFetch: fasta.fetch.bind(fasta),
-      })
-
-      const features = await cram.getRecordsForRange(1, 20000, 30000)
-      if (REWRITE_EXPECTED_DATA) {
-        fs.writeFileSync(
-          `test/data/extended/RNAseq_mapping_def.cram.test1.expected.json`,
-          JSON.stringify(features, null, '  '),
-        )
-      }
-
-      const expectedFeatures = await loadTestJSON(
-        'extended/RNAseq_mapping_def.cram.test1.expected.json',
-      )
-
-      expect(JsonClone(features)).toEqual(expectedFeatures)
-
-      const moreFeatures = await cram.getRecordsForRange(6, 12437859, 12437959)
-      if (REWRITE_EXPECTED_DATA) {
-        fs.writeFileSync(
-          `test/data/extended/RNAseq_mapping_def.cram.test2.expected.json`,
-          JSON.stringify(moreFeatures, null, '  '),
-        )
-      }
-
-      // const moreExpectedFeatures = await loadTestJSON(
-      //   'extended/RNAseq_mapping_def.cram.test2.expected.json',
-      // )
-
-      const moreFeatures2 = await cram.getRecordsForRange(6, 4765916, 4768415)
-      expect(moreFeatures2.length).toEqual(1)
-      expect(moreFeatures2[0].readName).toEqual('7033952-2')
-      expect(moreFeatures2[0].alignmentStart).toEqual(4767144)
-    },
-  )
 })
 
 describe('paired read test', () => {

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -25,18 +25,6 @@ function JsonClone(obj) {
   return JSON.parse(JSON.stringify(obj))
 }
 
-let extended = xit
-try {
-  if (fs.existsSync(require.resolve(`../data/extended/insilico_21.cram`))) {
-    extended = it
-  }
-} catch (e) {
-  // ignore
-  console.log(
-    'extended tests disabled, download the extended test dataset and fix all the symlinks in tests/data/extended to enable them',
-  )
-}
-
 const REWRITE_EXPECTED_DATA =
   typeof process !== 'undefined' &&
   process.env.CRAMJS_REWRITE_EXPECTED_DATA &&
@@ -47,7 +35,6 @@ module.exports = {
   testDataUrl,
   testDataFile,
   loadTestJSON,
-  extended,
   JsonClone,
   REWRITE_EXPECTED_DATA,
   fs,

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -1,7 +1,7 @@
 //@ts-nocheck
 import { CramFile } from '../src'
 
-import { testDataFile, extended } from './lib/util'
+import { testDataFile } from './lib/util'
 
 describe('CRAM reader', () => {
   it('can read a cram file definition', async () => {
@@ -36,59 +36,6 @@ describe('CRAM reader', () => {
       _endPosition: 45,
       refSeqId: 0,
       refSeqStart: 0,
-    })
-  })
-
-  extended('can read a bigger cram file', async () => {
-    const file = new CramFile({
-      filehandle: testDataFile('extended/insilico_21.cram'),
-    })
-    expect(await file.getDefinition()).toEqual({
-      fileId: '21_1mil.cram',
-      magic: 'CRAM',
-      majorVersion: 3,
-      minorVersion: 0,
-    })
-    expect(await (await file.getContainerById(0)).getHeader()).toEqual({
-      alignmentSpan: 0,
-      crc32: 2977905791,
-      _endPosition: 45,
-      _size: 19,
-      landmarks: [0, 3927],
-      length: 5901,
-      numBases: 0,
-      numBlocks: 2,
-      numLandmarks: 2,
-      numRecords: 0,
-      recordCounter: 0,
-      refSeqId: 0,
-      refSeqStart: 0,
-    })
-  })
-  extended('can read an even bigger cram file', async () => {
-    const file = new CramFile({
-      filehandle: testDataFile('extended/RNAseq_mapping_def.cram'),
-    })
-    expect(await file.getDefinition()).toEqual({
-      fileId: '-',
-      magic: 'CRAM',
-      majorVersion: 3,
-      minorVersion: 0,
-    })
-    expect(await (await file.getContainerById(1)).getHeader()).toEqual({
-      alignmentSpan: 574995,
-      crc32: 2139737710,
-      _size: 24,
-      _endPosition: 1178,
-      landmarks: [990],
-      length: 84878,
-      numBases: 651833,
-      numBlocks: 34,
-      numLandmarks: 1,
-      numRecords: 10000,
-      recordCounter: 0,
-      refSeqId: 0,
-      refSeqStart: 300,
     })
   })
 


### PR DESCRIPTION
This PR proposes removing the extended tests to fix e.g. #113 

else could possibly link the datasets from readme, document windows workaround, etc. if we want to retain them