### PR TITLE
Fix usage of the 'b' tag under situations in CRA4 where a Uint8Array is received instead of Buffer

### DIFF
--- a/src/cramFile/record.ts
+++ b/src/cramFile/record.ts
@@ -54,8 +54,7 @@ function decodeReadSequence(
 
         if (feature.code === 'b') {
           // specify a base pair for some reason
-          const ret = feature.data.split(',')
-          const added = String.fromCharCode(...ret)
+          const added = feature.data
           bases += added
           regionPos += added.length
         } else if (feature.code === 'B') {

--- a/src/cramFile/slice/decodeRecord.ts
+++ b/src/cramFile/slice/decodeRecord.ts
@@ -141,7 +141,11 @@ function decodeReadFeatures(
       return String.fromCharCode(data)
     }
     if (type === 'string') {
-      return data.toString('utf8')
+      let r = ''
+      for (let i = 0; i < data.byteLength; i++) {
+        r += String.fromCharCode(data[i])
+      }
+      return r
     }
     if (type === 'numArray') {
       return data.toArray()


### PR DESCRIPTION
didn't fully trace but in general, adapting code to just work from plain Uint8Array tends to be good since Buffer requires polyfill

fixes https://github.com/GMOD/jbrowse-components/issues/3427