### PR TITLE
Remove file length check pt 2.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@ export default tseslint.config(
       '*.mjs',
       'example/*',
       'src/htscodecs',
+      'coverage',
     ],
   },
   {

--- a/src/cramFile/codecs/_base.ts
+++ b/src/cramFile/codecs/_base.ts
@@ -41,5 +41,5 @@ export default abstract class CramCodec<
     coreDataBlock: CramFileBlock,
     blocksByContentId: Record<number, CramFileBlock>,
     cursors: Cursors,
-  ): DataTypeMapping[TResult]
+  ): DataTypeMapping[TResult] | undefined
 }

--- a/src/cramFile/codecs/byteArrayLength.ts
+++ b/src/cramFile/codecs/byteArrayLength.ts
@@ -32,22 +32,14 @@ export default class ByteArrayStopCodec extends CramCodec<
     cursors: Cursors,
   ) {
     const lengthCodec = this._getLengthCodec()
-    const arrayLength = lengthCodec.decode(
-      slice,
-      coreDataBlock,
-      blocksByContentId,
-      cursors,
-    )
+    const arrayLength =
+      lengthCodec.decode(slice, coreDataBlock, blocksByContentId, cursors) || 0
 
     const dataCodec = this._getDataCodec()
     const data = new Uint8Array(arrayLength)
     for (let i = 0; i < arrayLength; i += 1) {
-      data[i] = dataCodec.decode(
-        slice,
-        coreDataBlock,
-        blocksByContentId,
-        cursors,
-      )
+      data[i] =
+        dataCodec.decode(slice, coreDataBlock, blocksByContentId, cursors) || 0
     }
 
     return data

--- a/src/cramFile/codecs/external.ts
+++ b/src/cramFile/codecs/external.ts
@@ -1,5 +1,5 @@
 import CramCodec, { Cursor, Cursors } from './_base'
-import { CramMalformedError, CramUnimplementedError } from '../../errors'
+import { CramUnimplementedError } from '../../errors'
 import { CramFileBlock } from '../file'
 import CramSlice from '../slice'
 import { parseItf8 } from '../util'

--- a/src/cramFile/codecs/external.ts
+++ b/src/cramFile/codecs/external.ts
@@ -39,13 +39,9 @@ export default class ExternalCodec extends CramCodec<
   ) {
     const { blockContentId } = this.parameters
     const contentBlock = blocksByContentId[blockContentId]
-    if (!contentBlock) {
-      throw new CramMalformedError(
-        `no block found with content ID ${blockContentId}}`,
-      )
-    }
+
     const cursor = cursors.externalBlocks.getCursor(blockContentId)
-    return this._decodeData(contentBlock, cursor)
+    return contentBlock ? this._decodeData(contentBlock, cursor) : undefined
   }
 
   _decodeInt(contentBlock: CramFileBlock, cursor: Cursor) {

--- a/src/cramFile/container/index.ts
+++ b/src/cramFile/container/index.ts
@@ -28,9 +28,6 @@ export default class CramContainer {
     const sectionParsers = getSectionParsers(majorVersion)
 
     const block = await this.getFirstBlock()
-    if (block === undefined) {
-      return undefined
-    }
     if (block.contentType !== 'COMPRESSION_HEADER') {
       throw new CramMalformedError(
         `invalid content type ${block.contentType} in compression header block`,

--- a/src/cramFile/record.ts
+++ b/src/cramFile/record.ts
@@ -271,7 +271,7 @@ export default class CramRecord {
 
     this.readGroupId = readGroupId
     this.readName = readName
-    this.sequenceId = sequenceId
+    this.sequenceId = sequenceId!
     this.uniqueId = uniqueId
     this.templateSize = templateSize
     this.alignmentStart = alignmentStart

--- a/src/cramFile/slice/index.ts
+++ b/src/cramFile/slice/index.ts
@@ -198,16 +198,10 @@ export default class CramSlice {
     const { majorVersion } = await this.file.getDefinition()
     const sectionParsers = getSectionParsers(majorVersion)
     const containerHeader = await this.container.getHeader()
-    if (!containerHeader) {
-      throw new Error('no container header detected')
-    }
 
     const header = await this.file.readBlock(
       containerHeader._endPosition + this.containerPosition,
     )
-    if (header === undefined) {
-      throw new Error('block header undefined')
-    }
     if (header.contentType === 'MAPPED_SLICE_HEADER') {
       const content = parseItem(
         header.content,
@@ -239,9 +233,6 @@ export default class CramSlice {
     const blocks: CramFileBlock[] = new Array(header.parsedContent.numBlocks)
     for (let i = 0; i < blocks.length; i++) {
       const block = await this.file.readBlock(blockPosition)
-      if (block === undefined) {
-        continue
-      }
       blocks[i] = block
       blockPosition = blocks[i]!._endPosition
     }


### PR DESCRIPTION
currently, cram-js tries to access the "file size" but this requires special CORS configurations when accessing cross origin files that not all servers have

I determined that a major contributor to the "need" for file length check was a "test only" method called containerCount. while it containerCount could potentially be used by people outside of our tests, it is uncommon for web usage. threfore, i found a way to fix it where it just catches an error reading past the end of the file with a try/catch


random note: one of the tricky files to handle corectly with this PR was "test/data/grc37-1#HG03297.mapped.ILLUMINA.bwa.ESN.low_coverage.20130415.bam.cram"

I found that it was referencing 'mate records' that were undefined. this was maybe due to performing samtools view on a slice of the file, which resulted in it referring to mates in other slices. potentially it could be investigated further, but this PR has 100% matching snapshots still.

this PR does propagate some "undefined's" (where ::decode() can return undefined now) through the type system, related to where that decode can fail, related to what i hypothesize is that mate record not being defined, but the type system checks this edge case well and so it is accomodated by some basic workarounds for that undefined condition.

this is a re-attempt at https://github.com/GMOD/cram-js/pull/131